### PR TITLE
Use rsvg, add an example of SvgImage, and add new_checked() methods to types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 cascade = "0.1"
+cairo-rs = "0.8"
 derive_more = "0.99"
 gdk = "0.12"
 gio = "0.8"
@@ -13,6 +14,5 @@ glib = "0.9"
 gtk = { version = "0.8", features = ["v3_22"] }
 itertools = "0.8"
 log = "0.4"
-# resvg = { version = "0.8", features = ["cairo-backend"] }
-resvg = { git = "https://github.com/mmstick/resvg", features = ["cairo-backend"], branch = "cairo-update" }
+librsvg = { git = "https://gitlab.gnome.org/GNOME/librsvg", tag = "2.49.3" }
 uuid = "0.8"

--- a/examples/svg-view.rs
+++ b/examples/svg-view.rs
@@ -1,0 +1,18 @@
+use gtk;
+use gtk::prelude::*;
+use gtk_extras::SvgImage;
+use std::env;
+
+fn main() {
+    gtk::init().unwrap();
+
+    let path = env::args().skip(1).next().unwrap();
+    let svg_image = SvgImage::from_file(path).unwrap();
+    let drawing_area: gtk::DrawingArea = svg_image.into();
+
+    let window = gtk::Window::new(gtk::WindowType::Toplevel);
+    window.add(&drawing_area);
+    window.show_all();
+
+    gtk::main();
+}

--- a/src/functions/settings.rs
+++ b/src/functions/settings.rs
@@ -74,6 +74,10 @@ pub struct GeditPreferencesEditor(pub Settings);
 impl GeditPreferencesEditor {
     pub fn new() -> Self { Self(Settings::new("org.gnome.gedit.preferences.editor")) }
 
+    pub fn new_checked() -> Option<Self> {
+        new_checked("org.gnome.gedit.preferences.editor").map(Self)
+    }
+
     /// Get the active scheme
     pub fn scheme(&self) -> Option<GString> { self.0.get_string("scheme") }
 
@@ -89,6 +93,10 @@ pub struct GnomeDesktopInterface(pub Settings);
 
 impl GnomeDesktopInterface {
     pub fn new() -> Self { Self(Settings::new("org.gnome.desktop.interface")) }
+
+    pub fn new_checked() -> Option<Self> {
+        new_checked("org.gnome.desktop.interface").map(Self)
+    }
 
     /// Get the active GTK theme
     pub fn gtk_theme(&self) -> Option<GString> { self.0.get_string("gtk-theme") }

--- a/src/widgets_/svg_image.rs
+++ b/src/widgets_/svg_image.rs
@@ -1,26 +1,32 @@
+use cairo::Rectangle;
+use gio::{self, MemoryInputStream};
+use glib::Bytes;
 use gtk::prelude::*;
-use resvg::{backend_cairo, usvg, Options, ScreenSize};
+use librsvg::{CairoRenderer, Loader, LoadingError, SvgHandle};
 use std::path::Path;
 
-/// Renders SVG images into a GTK DrawingArea via resvg
+/// Renders SVG images into a GTK DrawingArea via rsvg
 ///
-/// [resvg]: https://github.com/RazrFalcon/resvg
+/// [rsvg]: https://gitlab.gnome.org/GNOME/librsvg
 #[derive(AsRef, Deref)]
 #[as_ref]
 #[deref]
 pub struct SvgImage(gtk::DrawingArea);
 
 impl SvgImage {
-    pub fn new(tree: usvg::Tree, opt: Options) -> Self {
+    pub fn new(handle: SvgHandle) -> Self {
         let drawing_area = cascade! {
             gtk::DrawingArea::new();
             ..connect_draw(move |w, cr| {
-                let s = ScreenSize::new(
-                    w.get_allocated_width() as u32,
-                    w.get_allocated_height() as u32,
-                ).expect("failed to create ScreenSize");
+                let rect = Rectangle {
+                    x: 0.0,
+                    y: 0.0,
+                    width: w.get_allocated_width() as f64,
+                    height: w.get_allocated_height() as f64,
+                };
 
-                backend_cairo::render_to_canvas(&tree, &opt, s, cr);
+                let renderer = CairoRenderer::new(&handle);
+                renderer.render_document(cr, &rect).unwrap();
                 Inhibit(false)
             });
         };
@@ -29,19 +35,20 @@ impl SvgImage {
     }
 
     /// Renders a SVG image which is already stored in-memory.
-    pub fn from_bytes(image: &[u8]) -> Result<Self, usvg::Error> {
-        let opt = Options::default();
-        let tree = usvg::Tree::from_data(image, &opt.usvg)?;
-
-        Ok(Self::new(tree, opt))
+    pub fn from_bytes(image: &[u8]) -> Result<Self, LoadingError> {
+        // Is there a way to avoid either cloning or unsafe cast to 'static?
+        let bytes = Bytes::from_owned(image.to_owned());
+        let stream = MemoryInputStream::new_from_bytes(&bytes);
+        let handle = Loader::new().read_stream(&stream,
+                                               None::<&gio::File>,
+                                               None::<&gio::Cancellable>)?;
+        Ok(Self::new(handle))
     }
 
     /// Renders a SVG image found at the given path.
-    pub fn from_file<P: AsRef<Path>>(image: P) -> Result<Self, usvg::Error> {
-        let opt = Options::default();
-        let tree = usvg::Tree::from_file(image, &opt.usvg)?;
-
-        Ok(Self::new(tree, opt))
+    pub fn from_file<P: AsRef<Path>>(image: P) -> Result<Self, LoadingError> {
+        let handle = Loader::new().read_path(image)?;
+        Ok(Self::new(handle))
     }
 }
 


### PR DESCRIPTION
The new methods are meant to help with fixing https://github.com/pop-os/gnome-control-center/issues/108 (I still need to make the appropriate change to the theme switcher).

A dependency of resvg was causing build failures, and the newer versions drop Cario support. So this switches to rsvg. It seems to be working quite well, testing with the example I've added.