### PR TITLE
feat: Make svg support an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,9 @@ glib = "0.9"
 gtk = { version = "0.8", features = ["v3_22"] }
 itertools = "0.8"
 log = "0.4"
-librsvg = { git = "https://gitlab.gnome.org/GNOME/librsvg", tag = "2.49.3" }
+librsvg = { git = "https://gitlab.gnome.org/GNOME/librsvg", tag = "2.49.3", optional = true }
 uuid = "0.8"
+
+[features]
+default = ["svg"]
+svg = ["librsvg"]

--- a/src/widgets_/mod.rs
+++ b/src/widgets_/mod.rs
@@ -1,5 +1,6 @@
 mod image_selection;
 mod revealing_button;
+#[cfg(feature = "svg")]
 mod svg_image;
 mod uuid_entry;
 mod variant_toggler;
@@ -7,10 +8,12 @@ mod variant_toggler;
 pub use self::{
     image_selection::{ImageSelection, SelectionVariant},
     revealing_button::RevealingButton,
-    svg_image::SvgImage,
     uuid_entry::UuidEntry,
     variant_toggler::{ToggleVariant, VariantToggler},
 };
+
+#[cfg(feature = "svg")]
+pub use self::svg_image::SvgImage;
 
 use gtk::prelude::*;
 


### PR DESCRIPTION
Since svg parsing requires support for css, xml, font rendering, etc., rsvg pulls in a lot of dependencies. It's probably best that it's optional.